### PR TITLE
global-state: list all variables on more cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ const byeText = bundle.formatPattern(byeMessage.value, { wrongVariable: 'Macabeu
 
 ## Asymmetric translations
 
+**tl;dr:** You should always use all variables that a message could need.
+
+**Detailed explanation:**
+
 Let's say that we have a `hello` message on our application and we should translate that to Japanese and Portuguese. Since in Japanese is more common to use the last name, and in Portuguese is more natural to use the first name, we'll have that:
 
 ```ftl
@@ -121,4 +125,21 @@ Despite that _in practice_ we could just use `firstName` or `lastName`, our type
 bundle.formatPattern(helloMessage.value, { firstName: 'Macabeus', lastName: 'Aquino' }) // ok
 bundle.formatPattern(helloMessage.value, { firstName: 'Macabeus' }) // error
 bundle.formatPattern(helloMessage.value, { lastName: 'Aquino' }) // error
+```
+
+Analogously on a message with selector. You should always use all variables:
+
+```ftl
+award =
+  { $place ->
+     [first]  You won first! Your prize is { $amount } bitcoins
+    *[other] You won { $place }! Congratulations!
+  }
+```
+
+```ts
+bundle.formatPattern(helloMessage.value, { place: 'first', amount: 0.1 }) // ok
+bundle.formatPattern(helloMessage.value, { place: 'second', amount: 0 }) // ok
+bundle.formatPattern(helloMessage.value, { place: 'first' }) // error
+bundle.formatPattern(helloMessage.value, { place: 'second' }) // error
 ```

--- a/src/global-state/list-messages-variables.ts
+++ b/src/global-state/list-messages-variables.ts
@@ -1,0 +1,38 @@
+import { Visitor, Message, VariableReference, Resource } from '@fluent/syntax'
+
+class VisitorListVariables extends Visitor {
+  result: Set<MessageVariable>
+
+  constructor() {
+    super()
+    this.result = new Set()
+  }
+
+  visitVariableReference(nodePlaceable: VariableReference) {
+    this.result.add(nodePlaceable.id.name as MessageVariable)
+  }
+}
+
+class VisitorListMessages extends Visitor {
+  result: { [messageIdentifier in string]: MessageVariable[] }
+
+  constructor() {
+    super()
+    this.result = {}
+  }
+
+  visitMessage(node: Message) {
+    const visitorListVariables = new VisitorListVariables()
+    visitorListVariables.visit(node)
+    this.result[node.id.name] = [...visitorListVariables.result].sort()
+  }
+}
+
+const listMessagesVariables = (ast: Resource) => {
+  const visitorMessage = new VisitorListMessages()
+  visitorMessage.visit(ast)
+
+  return visitorMessage.result
+}
+
+export default listMessagesVariables

--- a/test/global-state.test.ts
+++ b/test/global-state.test.ts
@@ -131,4 +131,38 @@ describe('global-state', () => {
       'how-are-you': [],
     })
   })
+
+  test('Should can read variables on a selector', () => {
+    const fixtureEn: CliFluentFile = {
+      path: 'en.ftl',
+      content: dedent`
+        emails =
+          { $unreadEmails ->
+              [one] { $name } has one unread email.
+            *[other] { $name } has { $unreadEmails } unread emails.
+          }
+      `,
+    }
+
+    updateGlobalState({ type: 'addContent', payload: fixtureEn })
+    const messagesVariablesPt = getMessagesVariables()
+    expect(messagesVariablesPt).toEqual({
+      emails: ['name', 'unreadEmails'],
+    })
+  })
+
+  test('Should can read variables on a built-in function', () => {
+    const fixtureEn: CliFluentFile = {
+      path: 'en.ftl',
+      content: dedent`
+        time-elapsed = Time elapsed: { NUMBER($duration, maximumFractionDigits: 0) }s.
+      `,
+    }
+
+    updateGlobalState({ type: 'addContent', payload: fixtureEn })
+    const messagesVariablesPt = getMessagesVariables()
+    expect(messagesVariablesPt).toEqual({
+      'time-elapsed': ['duration'],
+    })
+  })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "noImplicitAny": true,
     "moduleResolution": "node",
     "module": "es6",
-    "target": "es5",
+    "target": "es6",
     "strictNullChecks": true,
     "rootDirs": ["src", "test"],
     "esModuleInterop": true,


### PR DESCRIPTION
Now it's generating types for variables on selectors and built-in functions.
For example:

```ftl
award =
  { $place ->
     [first]  You won first! Your prize is { $amount } bitcoins
    *[other] You won { $place }! Congratulations!
  }
```

Now works as expected.