### PR TITLE
added --no-watch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,18 @@ To use the patched version of `Localized`, you should add the prop `typed`. For 
 
 Finish! Now you have amazing types on your translations messages 🎉
 
+## Flags
+
+### --no-watch
+
+If you just want to emit the type definition, without running the watcher, you can use the flag `--no-watch`.
+
+For instance:
+
+```
+> fluent-typescript vanilla ./assets/locales/ --no-watcha
+```
+
 # How types are compiled
 
 ## Asymmetric translations

--- a/cli/emit-fluent-type-module.js
+++ b/cli/emit-fluent-type-module.js
@@ -1,0 +1,22 @@
+const { buildFluentTypeModule } = require('../dist')
+
+const emitFluentTypeModule = (fileSystemApi, typeDefinitionTarget, typeDefinitionFilepath) => {
+  const fluentTypeModule = buildFluentTypeModule(typeDefinitionTarget)
+  const typeDefinitionFilename = `${typeDefinitionFilepath}/translations.ftl.d.ts`
+  fileSystemApi.writeFile(
+    typeDefinitionFilename,
+    fluentTypeModule,
+    { encoding: 'utf-8' },
+    (err) => {
+      if (err) {
+        console.log('❌ Error')
+        console.log(err)
+        return
+      }
+
+      console.log(`🏁 Type definition updated: ${typeDefinitionFilename}`)
+    }
+  )
+}
+
+module.exports = { emitFluentTypeModule }

--- a/cli/index.js
+++ b/cli/index.js
@@ -59,5 +59,11 @@ if (require.main === module) {
     return
   }
 
+  if (noWatchFlag !== undefined) {
+    console.error(`❌ Error: Unknown flag "${noWatchFlag}"`)
+    console.error('Example: fluent-typescript vanilla ./assets/locales/ --no-watch')
+    return
+  }
+
   startWatcher(fs, typeDefinitionTarget, typeDefinitionFilepath)
 }

--- a/cli/run-fluent-typescript.js
+++ b/cli/run-fluent-typescript.js
@@ -1,0 +1,18 @@
+const glob = require('glob')
+const { normalize } = require('path')
+const { start } = require('../dist')
+const { emitFluentTypeModule } = require('./emit-fluent-type-module')
+
+const runFluentTypescript = (fileSystemApi, typeDefinitionTarget, typeDefinitionFilepath) => {
+  glob('**/*.ftl', { ignore: ['node_modules/**/*', '.git/**/*'] }, (errors, matches) => {
+    const files = matches.map(path => ({
+      path: normalize(path),
+      content: fileSystemApi.readFileSync(path, { encoding: 'utf-8' }),
+    }))
+
+    start(files)
+    emitFluentTypeModule(fileSystemApi, typeDefinitionTarget, typeDefinitionFilepath)
+  })
+}
+
+module.exports = { runFluentTypescript }


### PR DESCRIPTION
I have added a no-watch option, for build systems.

this way it can be ensured that when the project is packed on a build server it will update the type definitions to the latest version.

since it is the only optional option, i just look for `--no-watch` on index forth of the process arguments. If in future there could be more it may be worth to add an command line argument parsing library.